### PR TITLE
Added integration with base theory solver for LRA using lar_solver

### DIFF
--- a/src/smt/smt_setup.cpp
+++ b/src/smt/smt_setup.cpp
@@ -20,6 +20,7 @@ Revision History:
 #include"smt_setup.h"
 #include"static_features.h"
 #include"theory_arith.h"
+#include"theory_lra.h"
 #include"theory_dense_diff_logic.h"
 #include"theory_diff_logic.h"
 #include"theory_utvpi.h"
@@ -437,7 +438,7 @@ namespace smt {
         m_params.m_arith_propagate_eqs = false;
         m_params.m_eliminate_term_ite  = true;
         m_params.m_nnf_cnf             = false;
-        setup_mi_arith();
+        setup_r_arith();
     }
 
     void setup::setup_QF_LRA(static_features const & st) {
@@ -462,7 +463,7 @@ namespace smt {
             m_params.m_restart_adaptive      = false;
         }
         m_params.m_arith_small_lemma_size = 32;
-        setup_mi_arith();
+        setup_r_arith();
     }
 
     void setup::setup_QF_LIA() {
@@ -706,6 +707,10 @@ namespace smt {
 
     void setup::setup_i_arith() {
         m_context.register_plugin(alloc(smt::theory_i_arith, m_manager, m_params));
+    }
+
+    void setup::setup_r_arith() {
+        m_context.register_plugin(alloc(smt::theory_lra, m_manager));
     }
 
     void setup::setup_mi_arith() {

--- a/src/smt/smt_setup.h
+++ b/src/smt/smt_setup.h
@@ -97,6 +97,7 @@ namespace smt {
         void setup_card();
         void setup_i_arith();
         void setup_mi_arith();
+        void setup_r_arith();
         void setup_fpa();
 
     public:

--- a/src/smt/theory_lra.cpp
+++ b/src/smt/theory_lra.cpp
@@ -133,7 +133,7 @@ namespace smt {
         svector<scope>         m_scopes;
         lp::stats              m_stats;
 
-        scoped_ptr<lean::lp_solver<lp::inf_numeral, rational> > m_solver;
+        scoped_ptr<lean::lar_solver> m_solver;
 
 
         void found_non_arith(expr* n) {
@@ -207,7 +207,7 @@ namespace smt {
         }
 
         void internalize() {
-            unsigned row = m_solver->row_count();
+            unsigned row = 0; // TBD m_solver->row_count();
             for (unsigned i = 0; i < m_vars.size(); ++i) {
                 theory_var column = m_vars[i];
                 rational const& coeff = m_coeffs[i];
@@ -217,10 +217,10 @@ namespace smt {
                 else {
                     m_columns[column] += coeff;
                 }
-                m_solver->set_row_column_coefficient(row, column, m_columns[column]);
+                // TBD: m_solver->set_row_column_coefficient(row, column, m_columns[column]);
             }
             
-            m_solver->add_constraint(lean::Equal, rational::zero(), row);
+            // TBD: m_solver->add_constraint(lean::Equal, rational::zero(), row);
 
             // reset the coefficients after they have been used.
             for (unsigned i = 0; i < m_vars.size(); ++i) {
@@ -248,7 +248,7 @@ namespace smt {
 
     public:
         imp(theory_lra& th, ast_manager& m): th(th), m(m), a(m), m_terms(m) {
-            m_solver = alloc(dual_simplex);
+            m_solver = alloc(lean::lar_solver); // dual_simplex;
         }
 
         ~imp() {
@@ -357,16 +357,16 @@ namespace smt {
                     switch (r.m_bound_kind) {
                     case lp::lower_t:
                         m_lower[r.m_v] = r.m_bound;
-                        m_solver->unset_low_bound(r.m_v);
+                        // TBD: m_solver->unset_low_bound(r.m_v);
                         if (r.m_bound) {
-                            m_solver->set_low_bound(r.m_v, *r.m_bound);
+                            // TBD: m_solver->set_low_bound(r.m_v, *r.m_bound);
                         }
                         break;
                     case lp::upper_t:
                         m_upper[r.m_v] = r.m_bound;
-                        m_solver->unset_upper_bound(r.m_v);
+                        // TBD: m_solver->unset_upper_bound(r.m_v);
                         if (r.m_bound) {
-                            m_solver->set_upper_bound(r.m_v, *r.m_bound);
+                            // TBD: m_solver->set_upper_bound(r.m_v, *r.m_bound);
                         }
                         break;
                     }
@@ -422,13 +422,13 @@ namespace smt {
             switch (k) {
             case lp::lower_t:
                 m_replay_bounds.push_back(lp::replay_bound(v, m_lower[v], k));
-                m_solver->set_low_bound(v, val);
+                // TBD: m_solver->set_low_bound(v, val);
                 m_lower[v] = val;
                 ++m_stats.m_assert_lower;
                 break;
             case lp::upper_t:
                 m_replay_bounds.push_back(lp::replay_bound(v, m_upper[v], k));
-                m_solver->set_upper_bound(v, val);
+                // TBD: m_solver->set_upper_bound(v, val);
                 m_upper[v] = val;
                 ++m_stats.m_assert_upper;
                 break;
@@ -437,8 +437,7 @@ namespace smt {
         }
 
         lbool make_feasible() {
-            m_solver->find_maximal_solution();
-            lean::lp_status status = m_solver->get_status();
+            lean::lp_status status = m_solver->check();
             switch (status) {
             case lean::lp_status::INFEASIBLE:
                 return l_false;
@@ -452,6 +451,8 @@ namespace smt {
         }
 
         void failed() {
+            // TBD: extract core as a conflict clause.
+            // m_solver->get_infeasible_evidence(evidence);
             // restore_assignment();
         }
 
@@ -462,7 +463,8 @@ namespace smt {
 
         }
         void init_model(model_generator & m) {
-
+            // 
+            // TBD: m_solver->get_model(variable_values);
         }
         model_value_proc * mk_value(enode * n, model_generator & mg) {
             return 0;

--- a/src/smt/theory_lra.h
+++ b/src/smt/theory_lra.h
@@ -74,6 +74,11 @@ namespace smt {
         
         virtual model_value_proc * mk_value(enode * n, model_generator & mg);
 
+        virtual bool get_value(enode* n, expr_ref& r) {
+            UNREACHABLE();
+            return false;
+        }
+
         virtual bool validate_eq_in_model(theory_var v1, theory_var v2, bool is_true) const;
                 
         virtual void display(std::ostream & out) const;

--- a/src/util/lp/lar_solver.cpp
+++ b/src/util/lp/lar_solver.cpp
@@ -648,12 +648,19 @@ std::string lar_solver::get_variable_name(var_index vi) const {
 // ********** print region start
 void lar_solver::print_constraint(constraint_index ci, std::ostream & out) {
     if (m_normalized_constraints.size() <= ci) {
-        std::string s = "constraint " + T_to_string(ci) + " is not found";
-        out << s << std::endl;
+        out << "constraint " << T_to_string(ci) << " is not found";
+        out << std::endl;
         return;
     }
 
-    print_constraint(&m_normalized_constraints[ci], out);
+    print_constraint(&m_normalized_constraints[ci], out); // REVIEW: this one does not produce a newline.
+}
+
+void lar_solver::print_constraints(std::ostream& out) {
+    for (size_t i = 0; i < m_normalized_constraints.size(); ++i) {
+        print_constraint(&m_normalized_constraints[i], out);
+        out << std::endl;
+    }
 }
 
 void lar_solver::print_canonic_left_side(const canonic_left_side & c, std::ostream & out) {

--- a/src/util/lp/lar_solver.h
+++ b/src/util/lp/lar_solver.h
@@ -222,6 +222,8 @@ public:
 
     std::string get_variable_name(var_index vi) const;
 
+    void print_constraints(std::ostream & out);
+
     void print_constraint(constraint_index ci, std::ostream & out);
 
     void print_canonic_left_side(const canonic_left_side & c, std::ostream & out);

--- a/src/util/lp/lp_core_solver_base.h
+++ b/src/util/lp/lp_core_solver_base.h
@@ -81,6 +81,9 @@ public:
      }
 
     std::vector<unsigned> & non_basis() {
+        if (m_factorization == nullptr) {
+            init_factorization(m_factorization, m_A, m_basis, m_basis_heading, m_settings, m_non_basic_columns);
+        }
         return m_factorization->m_non_basic_columns;
     }
 

--- a/src/util/lp/lp_primal_core_solver.cpp
+++ b/src/util/lp/lp_primal_core_solver.cpp
@@ -556,6 +556,9 @@ template <typename T, typename X>  unsigned lp_primal_core_solver<T, X>::get_num
     if (ret > 300) {
         ret = (unsigned)(ret * this->m_settings.percent_of_entering_to_check / 100);
     }
+	if (ret == 0) {
+		return 0;
+	}
     return std::max(static_cast<unsigned>(my_random() % ret), 1u);
 }
 

--- a/src/util/lp/lp_settings.h
+++ b/src/util/lp/lp_settings.h
@@ -43,6 +43,10 @@ enum lp_status {
 
 const char* lp_status_to_string(lp_status status);
 
+inline std::ostream& operator<<(std::ostream& out, lp_status status) {
+    return out << lp_status_to_string(status);
+}
+
 lp_status lp_status_from_string(std::string status);
 
 enum non_basic_column_value_position { at_low_bound, at_upper_bound, at_fixed, free_of_bounds };

--- a/src/util/lp/lp_utils.h
+++ b/src/util/lp/lp_utils.h
@@ -8,18 +8,19 @@
 #pragma once
 #include <string>
 #include "util/lp/numeric_pair.h"
+#include "util/debug.h"
+
 #ifdef lp_for_z3
 namespace lean {
     inline void throw_exception(const std::string & str) {
          throw default_exception(str);
     }
     typedef z3_exception exception;
-#ifdef LEAN_DEBUG
-    inline void lean_assert(bool b) {}
-#else
-    #define lean_assert(_x_) {}
-#endif
-    inline void lean_unreachable() { lean_assert(false); }
+
+#define lean_assert(_x_) { SASSERT(_x_); }
+
+    
+    inline void lean_unreachable() { } // TBD:
     template <typename X> inline X zero_of_type() { return numeric_traits<X>::zero(); }
     template <typename X> inline X one_of_type() { return numeric_traits<X>::one(); }
     template <typename X> inline bool is_zero(const X & v) { return numeric_traits<X>::is_zero(v); }
@@ -55,7 +56,7 @@ template<typename S, typename T> struct hash<pair<S, T>> {
 #include "util/numerics/mpq.h"
 #include "util/numerics/numeric_traits.h"
 #include "util/numerics/double.h"
-#include "util/debug.h"
+
 #ifdef __CLANG__
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wmismatched-tags"

--- a/src/util/lp/lu.cpp
+++ b/src/util/lp/lu.cpp
@@ -311,7 +311,7 @@ template <typename T, typename X>
 void lu<T, X>::perform_transformations_on_w(indexed_vector<T>& w) {
     apply_lp_lists_to_w(w);
     m_Q.apply_reverse_from_left(w);
-    lean_assert(numeric_traits<T>::precise() || check_vector_for_small_values(w, m_settings));
+    // TBD does not compile: lean_assert(numeric_traits<T>::precise() || check_vector_for_small_values(w, m_settings));
 }
 
 // see Chvatal 24.3
@@ -325,7 +325,7 @@ template <typename T, typename X>
 void lu<T, X>::apply_lp_lists_to_w(indexed_vector<T> & w) {
     for (unsigned i = 0; i < m_tail.size(); i++) {
         m_tail[i]->apply_from_left_to_T(w, m_settings);
-        lean_assert(check_vector_for_small_values(w, m_settings));
+        // TBD does not compile: lean_assert(check_vector_for_small_values(w, m_settings));
     }
 }
 template <typename T, typename X>
@@ -557,7 +557,7 @@ void lu<T, X>::create_initial_factorization(){
         return;
     }
     if (j == m_dim) {
-        lean_assert(m_U.is_upper_triangular_and_maximums_are_set_correctly_in_rows(m_settings));
+        // TBD does not compile: lean_assert(m_U.is_upper_triangular_and_maximums_are_set_correctly_in_rows(m_settings));
         return;
     }
     j++;
@@ -643,7 +643,7 @@ void lu<T, X>::pivot_and_solve_the_system(unsigned replaced_column, unsigned low
             }
         }
     }
-    lean_assert(m_row_eta_work_vector.is_OK());
+    // TBD does not compile: lean_assert(m_row_eta_work_vector.is_OK());
 }
 // see Achim Koberstein's thesis page 58, but here we solve the system and pivot to the last
 // row at the same time
@@ -702,8 +702,8 @@ void lu<T, X>::replace_column(unsigned leaving, T pivot_elem, indexed_vector<T> 
         push_matrix_to_tail(row_eta);
     }
     calculate_Lwave_Pwave_for_bump(replaced_column, lowest_row_of_the_bump);
-     lean_assert(m_U.is_upper_triangular_and_maximums_are_set_correctly_in_rows(m_settings));
-    lean_assert(w.is_OK() && m_row_eta_work_vector.is_OK());
+    // TBD does not compile: lean_assert(m_U.is_upper_triangular_and_maximums_are_set_correctly_in_rows(m_settings));
+    // TBD does not compile: lean_assert(w.is_OK() && m_row_eta_work_vector.is_OK());
 }
 template <typename T, typename X>
 void lu<T, X>::calculate_Lwave_Pwave_for_bump(unsigned replaced_column, unsigned lowest_row_of_the_bump){

--- a/src/util/lp/row_eta_matrix.cpp
+++ b/src/util/lp/row_eta_matrix.cpp
@@ -44,7 +44,7 @@ void row_eta_matrix<T, X>::apply_from_left_local_to_T(indexed_vector<T> & w, lp_
         auto it = std::find(w.m_index.begin(), w.m_index.end(), m_row);
         w.m_index.erase(it);
     }
-    lean_assert(check_vector_for_small_values(w, settings));
+    // TBD: lean_assert(check_vector_for_small_values(w, settings));
 }
 
 template <typename T, typename X>
@@ -66,7 +66,7 @@ void row_eta_matrix<T, X>::apply_from_left_local_to_X(indexed_vector<X> & w, lp_
         auto it = std::find(w.m_index.begin(), w.m_index.end(), m_row);
         w.m_index.erase(it);
     }
-    lean_assert(check_vector_for_small_values(w, settings));
+    // TBD: does not compile lean_assert(check_vector_for_small_values(w, settings));
 }
 
 template <typename T, typename X>

--- a/src/util/lp/row_eta_matrix.h
+++ b/src/util/lp/row_eta_matrix.h
@@ -35,7 +35,7 @@ public:
     m_dimension(dim),
 #endif
     m_row_start(row_start), m_row(row) {
-        lean_assert(dim > 0);
+        // TBD does not compile: lean_assert(dim > 0);
     }
 
     void print(std::ostream & out) {

--- a/src/util/lp/sparse_matrix.cpp
+++ b/src/util/lp/sparse_matrix.cpp
@@ -400,8 +400,8 @@ void sparse_matrix<T, X>::solve_y_U(std::vector<T> & y) const { // works by rows
 #ifdef LEAN_DEBUG
     // T * rs = clone_vector<T>(y, dimension());
 #endif
-    unsigned end = dimension() - 1;
-    for (unsigned i = 0; i < end; i++) {
+    unsigned end = dimension();
+    for (unsigned i = 0; i + 1 < end; i++) {
         // all y[i] has correct values already
         const T & yv = y[i];
         if (numeric_traits<T>::is_zero(yv)) continue;

--- a/src/util/lp/static_matrix.h
+++ b/src/util/lp/static_matrix.h
@@ -189,6 +189,6 @@ public:
 
     T get_row_balance(unsigned row) const;
 
-    bool col_val_equal_to_row_val() const;
+    bool col_val_equal_to_row_val() const { return true; } // TBD: has no definition.
 };
 }


### PR DESCRIPTION
Basic tests work now.
Try for example by commenting/uncommenting assertions in below.

    (set-logic QF_LRA)
    (declare-const x Real)
    (declare-const y Real)
    (declare-const z Real)
    (assert (<= x (+ (* 2 y) 1)))
    (assert (< x z))
    (assert (< x y))
    ;(assert (<= z x))
    (check-sat)
    (get-model)

and from the command-line z3.exe test.smt2, where test.smt2 is the file containing the above assertions.

The lar_solver crashes if we add a constraint without variables. 
In debug mode it asserts. Something more permissive (with parameter checks) would be useful.

The debug assertions were always disabled before. The code does not compile when enabling the debug assertions. Many functions are not defined. I added TBD markers where debug assertions have been commented out. I get the following debug assertion on the empty tableau:

File: C:\lev\z3\src\util/lp/permutation_matrix.cpp
Line: 11
length > 0

The pull request also fixes crashes when the solver is called with an empty tableau.

